### PR TITLE
Support multi-host definitions

### DIFF
--- a/cmd/parsers/traefik_v2/client.go
+++ b/cmd/parsers/traefik_v2/client.go
@@ -74,8 +74,12 @@ func (t *TraefikV2Client) extractHosts(rules []string) []string {
 			continue
 		}
 
-		newHost := re.FindStringSubmatch(v)
-		hosts = append(hosts, strings.Replace(newHost[1], "Host:", "", -1))
+		newHosts := re.FindAllStringSubmatch(v, -1)
+
+		for _, newHost := range newHosts {
+			fmt.Println(newHost)
+			hosts = append(hosts, strings.Replace(newHost[1], "Host:", "", -1))
+		}
 	}
 
 	sort.Strings(hosts)

--- a/cmd/parsers/traefik_v2/client.go
+++ b/cmd/parsers/traefik_v2/client.go
@@ -77,7 +77,6 @@ func (t *TraefikV2Client) extractHosts(rules []string) []string {
 		newHosts := re.FindAllStringSubmatch(v, -1)
 
 		for _, newHost := range newHosts {
-			fmt.Println(newHost)
 			hosts = append(hosts, strings.Replace(newHost[1], "Host:", "", -1))
 		}
 	}

--- a/cmd/parsers/traefik_v2/client_test.go
+++ b/cmd/parsers/traefik_v2/client_test.go
@@ -25,14 +25,18 @@ func Test_extractHosts(t *testing.T) {
 					"Host(`Some.WWW.test.com.asd`)",
 					"Host(`test`);PathPrefix(`/api/`)",
 					"Host(`test`) && PathPrefix:/api/",
+					"Host(`test.some.asdf`) || Host(`test.com.zxc`) || Host(`some.test.zxc`)",
 				},
 			},
 			want: []string{
 				"Some.WWW.test.com.asd",
 				"gateway.gateway.docker.localhost",
+				"some.test.zxc",
 				"test",
 				"test",
 				"test.com.asd",
+				"test.com.zxc",
+				"test.some.asdf",
 			},
 		},
 	}


### PR DESCRIPTION
Traefik supports defining hosts as
```
Host(`host1`) || Host(`host2`) || Host(`host3`)
```

according to https://doc.traefik.io/traefik/routing/routers/

However they are not being parsed at the moment because only the first match is taken into account. This PR fixes that.